### PR TITLE
Use JWT Features instead of Introspect Endpoint

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -14,9 +13,6 @@ import (
 	events "go.1password.io/eventsapi-splunk/api"
 	"go.1password.io/eventsapi-splunk/utils"
 )
-
-const ItemUsageFeatureScope = "itemusages"
-const SignInAttemptsFeatureScope = "signinattempts"
 
 var EventBuildType string // Injected at build time so we can make multiple apps
 type EnvConfig struct {
@@ -31,17 +27,17 @@ type EnvConfig struct {
 // Gets environment variables and normalizes values to EnvConfig.
 // Note that the toml parsing library does not support BOM characters.
 // LoadConfig must trim a BOM prefix before passing the config bytes to the parser.
-func loadConfig() (*EnvConfig, error) {
+func loadConfig() (*EnvConfig, *utils.JWTClaims, error) {
 	log.Println("Loading config")
 	splunkHome := os.Getenv("SPLUNK_HOME")
 	if splunkHome == "" {
-		return nil, fmt.Errorf("SPLUNK_HOME environment variable must be set")
+		return nil, nil, fmt.Errorf("SPLUNK_HOME environment variable must be set")
 	}
 
 	configPath := splunkHome + "/etc/apps/onepassword_events_api/local/events_reporting.conf"
 	configFile, err := os.Open(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not open config file: %w", err)
+		return nil, nil, fmt.Errorf("could not open config file: %w", err)
 	}
 	defer configFile.Close()
 
@@ -52,7 +48,7 @@ func loadConfig() (*EnvConfig, error) {
 	}
 	var lc LocalConfig
 	if _, err := toml.DecodeReader(br, &lc); err != nil {
-		return nil, fmt.Errorf("could not decode toml config file: %w", err)
+		return nil, nil, fmt.Errorf("could not decode toml config file: %w", err)
 	}
 	config := lc.Config
 	config.ItemUsageCursorFile = path.Join(splunkHome, config.ItemUsageCursorFile)
@@ -60,7 +56,7 @@ func loadConfig() (*EnvConfig, error) {
 
 	jwt, err := utils.ParseJWTClaims(config.AuthToken)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	url, err := jwt.GetEventsURL()
@@ -70,13 +66,13 @@ func loadConfig() (*EnvConfig, error) {
 		config.Url = url
 	}
 
-	return &config, nil
+	return &config, jwt, nil
 }
 
 func main() {
 	log.Println("Booting...")
 
-	env, err := loadConfig()
+	env, jwt, err := loadConfig()
 	if err != nil {
 		err := fmt.Errorf("could not start: %w", err)
 		panic(err)
@@ -88,15 +84,10 @@ func main() {
 	}
 
 	eventsAPI := events.NewEventsAPI(env.AuthToken, env.Url)
-	res, err := eventsAPI.Introspect(context.TODO())
-	if err != nil {
-		err := fmt.Errorf("introspect request failed: %w", err)
-		panic(err)
-	}
 
-	if utils.ContainsString(SignInAttemptsFeatureScope, res.Features) && EventBuildType == SignInAttemptsFeatureScope {
+	if jwt.HaveSignInAttemptsFeature() && EventBuildType == utils.SignInAttemptsFeatureScope {
 		actions.StartSignIns(env.SignInCursorFile, env.Limit, &env.StartAt, eventsAPI)
-	} else if utils.ContainsString(ItemUsageFeatureScope, res.Features) && EventBuildType == ItemUsageFeatureScope {
+	} else if jwt.HaveItemUsageFeature() && EventBuildType == utils.ItemUsageFeatureScope {
 		actions.StartItemUsages(env.ItemUsageCursorFile, env.Limit, &env.StartAt, eventsAPI)
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -85,9 +85,9 @@ func main() {
 
 	eventsAPI := events.NewEventsAPI(env.AuthToken, env.Url)
 
-	if jwt.HaveSignInAttemptsFeature() && EventBuildType == utils.SignInAttemptsFeatureScope {
+	if jwt.Features.Contains(utils.SignInAttemptsFeatureScope) && EventBuildType == utils.SignInAttemptsFeatureScope {
 		actions.StartSignIns(env.SignInCursorFile, env.Limit, &env.StartAt, eventsAPI)
-	} else if jwt.HaveItemUsageFeature() && EventBuildType == utils.ItemUsageFeatureScope {
+	} else if jwt.Features.Contains(utils.ItemUsageFeatureScope) && EventBuildType == utils.ItemUsageFeatureScope {
 		actions.StartItemUsages(env.ItemUsageCursorFile, env.Limit, &env.StartAt, eventsAPI)
 	}
 }

--- a/src/utils/jwt.go
+++ b/src/utils/jwt.go
@@ -7,9 +7,11 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+type Features []string
+
 type JWTClaims struct {
 	Audience []string `json:"aud"`
-	Features []string `json:"1password.com/fts"`
+	Features Features `json:"1password.com/fts"`
 }
 
 const AudienceDEPRECATED = "com.1password.streamingservice"
@@ -46,10 +48,11 @@ func (t *JWTClaims) GetEventsURL() (string, error) {
 	return fmt.Sprintf("https://%s", t.Audience[0]), nil
 }
 
-func (t *JWTClaims) HaveSignInAttemptsFeature() bool {
-	return ContainsString(SignInAttemptsFeatureScope, t.Features)
-}
-
-func (t *JWTClaims) HaveItemUsageFeature() bool {
-	return ContainsString(ItemUsageFeatureScope, t.Features)
+func (s Features) Contains(v string) bool {
+	for _, a := range s {
+		if a == v {
+			return true
+		}
+	}
+	return false
 }

--- a/src/utils/jwt.go
+++ b/src/utils/jwt.go
@@ -9,9 +9,13 @@ import (
 
 type JWTClaims struct {
 	Audience []string `json:"aud"`
+	Features []string `json:"1password.com/fts"`
 }
 
 const AudienceDEPRECATED = "com.1password.streamingservice"
+
+const ItemUsageFeatureScope = "itemusages"
+const SignInAttemptsFeatureScope = "signinattempts"
 
 func ParseJWTClaims(token string) (*JWTClaims, error) {
 	t, err := jwt.ParseSigned(token)
@@ -36,8 +40,16 @@ func ParseJWTClaims(token string) (*JWTClaims, error) {
 
 func (t *JWTClaims) GetEventsURL() (string, error) {
 	if t.Audience[0] == AudienceDEPRECATED {
-		return "", errors.New("Token does not have a url.")
+		return "", errors.New("token does not have a url")
 	}
 
 	return fmt.Sprintf("https://%s", t.Audience[0]), nil
+}
+
+func (t *JWTClaims) HaveSignInAttemptsFeature() bool {
+	return ContainsString(SignInAttemptsFeatureScope, t.Features)
+}
+
+func (t *JWTClaims) HaveItemUsageFeature() bool {
+	return ContainsString(ItemUsageFeatureScope, t.Features)
 }


### PR DESCRIPTION
This PR extracts the token's features from `1password.com/fts` and uses the extracted features to determine if the token have Sign In Attempts or Item Usages feature instead of using the introspect API.

To test this PR, create a token with only one of Sign In Attempt or Item Usage feature. Only one of the worker should start.