### PR TITLE
Strip sub-second parts from printed events timestamps.

### DIFF
--- a/src/api/fixedformattime.go
+++ b/src/api/fixedformattime.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"time"
+)
+
+const fixedFormatTimeLayout = time.RFC3339
+
+type FixedFormatTime time.Time
+
+func (t *FixedFormatTime) UnmarshalJSON(data []byte) error {
+	// Ignore null, like in the main JSON package.
+	if string(data) == "null" {
+		return nil
+	}
+	// Fractional seconds are handled implicitly by Parse.
+	var err error
+	var v time.Time
+	v, err = time.Parse(`"`+fixedFormatTimeLayout+`"`, string(data))
+	*t = FixedFormatTime(v)
+	return err
+}
+
+func (t FixedFormatTime) MarshalJSON() ([]byte, error) {
+	v := time.Time(t)
+	if y := v.Year(); y < 0 || y >= 10000 {
+		// RFC 3339 is clear that years are 4 digits exactly.
+		// See golang.org/issue/4556#c15 for more discussion.
+		return nil, errors.New("FixedFormatTime.MarshalJSON: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(fixedFormatTimeLayout)+2)
+	b = append(b, '"')
+	b = v.AppendFormat(b, fixedFormatTimeLayout)
+	b = append(b, '"')
+	return b, nil
+}

--- a/src/api/fixedformattime_test.go
+++ b/src/api/fixedformattime_test.go
@@ -1,0 +1,79 @@
+package api_test
+
+import (
+	"testing"
+	"time"
+
+	"go.1password.io/eventsapi-splunk/api"
+)
+
+func TestFixedFormatTime_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       api.FixedFormatTime
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Marshal without sub-second",
+			t:       api.FixedFormatTime(mustParseTime(time.RFC3339Nano, "2021-07-07T13:51:12Z")),
+			want:    `"2021-07-07T13:51:12Z"`,
+			wantErr: false,
+		},
+		{
+			name:    "Marshal with sub-second",
+			t:       api.FixedFormatTime(mustParseTime(time.RFC3339Nano, "2021-07-07T13:51:12.623Z")),
+			want:    `"2021-07-07T13:51:12Z"`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.t.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got := string(got); got != tt.want {
+				t.Errorf("MarshalJSON() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFixedFormatTime_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       api.FixedFormatTime
+		json    string
+		wantErr bool
+	}{
+		{
+			name:    "Unmarshal without sub-second",
+			t:       api.FixedFormatTime{},
+			json:    `"2021-07-07T13:51:12Z"`,
+			wantErr: false,
+		},
+		{
+			name:    "Unmarshal with sub-second",
+			t:       api.FixedFormatTime{},
+			json:    `"2021-07-07T13:51:12.623Z"`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.t.UnmarshalJSON([]byte(tt.json)); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func mustParseTime(layout string, value string) time.Time {
+	t, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/src/api/itemusages.go
+++ b/src/api/itemusages.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 type ItemUsage struct {
 	UUID        string          `json:"uuid"`
-	Timestamp   time.Time       `json:"timestamp"`
+	Timestamp   FixedFormatTime `json:"timestamp"`
 	UsedVersion uint32          `json:"used_version"`
 	VaultUUID   string          `json:"vault_uuid"`
 	ItemUUID    string          `json:"item_uuid"`

--- a/src/api/signinattempts.go
+++ b/src/api/signinattempts.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 type SignInAttempt struct {
 	UUID        string                  `json:"uuid"`
 	SessionUUID string                  `json:"session_uuid"`
-	Timestamp   time.Time               `json:"timestamp"`
+	Timestamp   FixedFormatTime         `json:"timestamp"`
 	Country     string                  `json:"country"`
 	Category    string                  `json:"category"`
 	Type        string                  `json:"type"`


### PR DESCRIPTION
This PR strips sub-second precision from all printed events.   

```
cd src
go test go.1password.io/eventsapi-splunk/api
```