### PR TITLE
Sign-in attempts dashboard: customizable stats grouping

### DIFF
--- a/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
@@ -14,8 +14,8 @@
       <fieldForValue>index</fieldForValue>
       <search>
         <query>index=* sourcetype="1password:insights:item_usages" | dedup index | table index</query>
-        <earliest>-24h@h</earliest>
-        <latest>now</latest>
+        <earliest>0</earliest>
+        <latest></latest>
       </search>
     </input>
   </fieldset>

--- a/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
@@ -18,6 +18,13 @@
         <latest></latest>
       </search>
     </input>
+    <input type="dropdown" token="top_users_by">
+      <label>Top Users By</label>
+      <default>User UUID</default>
+      <choice value="uuid">User UUID</choice>
+      <choice value="email">User Email</choice>
+      <choice value="name">User Name</choice>
+    </input>
   </fieldset>
   <row>
     <panel>
@@ -89,12 +96,12 @@
       <chart>
         <title>Top Item Users</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:item_usages" | stats count by user.email | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:item_usages" | stats count by user.$top_users_by$ | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">90</option>
-        <option name="charting.axisTitleX.text">email</option>
+        <option name="charting.axisTitleX.text">$top_users_by$</option>
         <option name="charting.chart">column</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>

--- a/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/item_usage_dashboard.xml
@@ -89,7 +89,7 @@
       <chart>
         <title>Top Item Users</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:item_usages" |  stats count by user.email | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:item_usages" | stats count by user.email | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>

--- a/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
@@ -18,6 +18,13 @@
         <latest>now</latest>
       </search>
     </input>
+    <input type="dropdown" token="bar_charts_by">
+      <label>Bar Charts By</label>
+      <default>User UUID</default>
+      <choice value="uuid">User UUID</choice>
+      <choice value="email">User Email</choice>
+      <choice value="name">User Name</choice>
+    </input>
   </fieldset>
   <row>
     <panel>
@@ -89,12 +96,12 @@
       <chart>
         <title>Top Failed Sign-ins</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category!=success |  stats count by target_user.uuid | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category!=success |  stats count by target_user.$bar_charts_by$ | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">45</option>
-        <option name="charting.axisTitleX.text">email</option>
+        <option name="charting.axisTitleX.text">$bar_charts_by$</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.showDataLabels">all</option>
         <option name="charting.chart.stackMode">default</option>
@@ -108,12 +115,12 @@
       <chart>
         <title>Top Sign-ins</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category=success |  stats count by target_user.uuid | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category=success |  stats count by target_user.$bar_charts_by$ | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">45</option>
-        <option name="charting.axisTitleX.text">email</option>
+        <option name="charting.axisTitleX.text">$bar_charts_by$</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.stackMode">default</option>
         <option name="charting.drilldown">none</option>

--- a/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
@@ -14,8 +14,8 @@
       <fieldForValue>index</fieldForValue>
       <search>
         <query>index=* sourcetype="1password:insights:signin_attempts" | dedup index | table index</query>
-        <earliest>-24h@h</earliest>
-        <latest>now</latest>
+        <earliest>0</earliest>
+        <latest></latest>
       </search>
     </input>
     <input type="dropdown" token="bar_charts_by">

--- a/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
+++ b/app/onepassword_events_api/default/data/ui/views/signin_attempts_dashboard.xml
@@ -18,8 +18,8 @@
         <latest></latest>
       </search>
     </input>
-    <input type="dropdown" token="bar_charts_by">
-      <label>Bar Charts By</label>
+    <input type="dropdown" token="top_users_by">
+      <label>Top Users By</label>
       <default>User UUID</default>
       <choice value="uuid">User UUID</choice>
       <choice value="email">User Email</choice>
@@ -96,12 +96,12 @@
       <chart>
         <title>Top Failed Sign-ins</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category!=success |  stats count by target_user.$bar_charts_by$ | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category!=success |  stats count by target_user.$top_users_by$ | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">45</option>
-        <option name="charting.axisTitleX.text">$bar_charts_by$</option>
+        <option name="charting.axisTitleX.text">$top_users_by$</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.showDataLabels">all</option>
         <option name="charting.chart.stackMode">default</option>
@@ -115,12 +115,12 @@
       <chart>
         <title>Top Sign-ins</title>
         <search>
-          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category=success |  stats count by target_user.$bar_charts_by$ | sort - count</query>
+          <query>index=$index$ sourcetype="1password:insights:signin_attempts"| spath category | search category=success |  stats count by target_user.$top_users_by$ | sort - count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">45</option>
-        <option name="charting.axisTitleX.text">$bar_charts_by$</option>
+        <option name="charting.axisTitleX.text">$top_users_by$</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.stackMode">default</option>
         <option name="charting.drilldown">none</option>


### PR DESCRIPTION
This PR allows the user to select a field to be used when grouping the stats of _Sign-in attempts bar charts_.   

**New drop-down for selecting the grouping field**  
![dropdown](https://user-images.githubusercontent.com/167090/134064932-cdcfc5fd-d3e0-4f48-84fa-33ec315f9ebf.png)

**Bar charts where the stats grouping is done by user name**  
![bar_charts_by_name](https://user-images.githubusercontent.com/167090/134065065-aafda275-d283-4d3b-95b4-40ed70cd80bf.png)

