### PR TITLE
Update nanoid

### DIFF
--- a/app/onepassword_events_api/package-lock.json
+++ b/app/onepassword_events_api/package-lock.json
@@ -1042,9 +1042,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.1.23",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -2753,9 +2753,9 @@
             }
         },
         "nanoid": {
-            "version": "3.1.23",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
             "dev": true
         },
         "neo-async": {


### PR DESCRIPTION
This PR update nanoid from 3.1.23 to 3.3.4 to address this CVE: https://github.com/advisories/GHSA-qrpm-p2h7-hrv2